### PR TITLE
Update metadata for support of 3.12 and 3.14

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["3.10"], "uuid": "disable-screenshield@lgpasquale.com", "name": "Disable Screen Shield", "description": "Disable screen shield when screen lock is disabled"}
+{"shell-version": ["3.10", "3.12", "3.14"], "uuid": "disable-screenshield@lgpasquale.com", "name": "Disable Screen Shield", "description": "Disable screen shield when screen lock is disabled"}


### PR DESCRIPTION
Up to now there was Gnome 3.10 supported only. Since the extension works
for 3.12 and 3.14 as well, these versions have been added to the
metadata file.
